### PR TITLE
Improve strategy security

### DIFF
--- a/app/controllers/devise/saml_sessions_controller.rb
+++ b/app/controllers/devise/saml_sessions_controller.rb
@@ -5,6 +5,7 @@ class Devise::SamlSessionsController < Devise::SessionsController
 
   skip_before_action :verify_authenticity_token, raise: false
   prepend_before_action :verify_signed_out_user, :store_info_for_sp_initiated_logout, only: :destroy
+  prepend_before_action :allow_saml_authentication!, only: :create
 
   def new
     idp_entity_id = get_idp_entity_id(params)
@@ -93,5 +94,9 @@ class Devise::SamlSessionsController < Devise::SessionsController
     params[:RelayState] = relay_state if relay_state
 
     OneLogin::RubySaml::SloLogoutresponse.new.create(saml_config, logout_request_id, nil, params)
+  end
+
+  def allow_saml_authentication!
+    request.env['devise.allow_saml_authentication'] = true
   end
 end


### PR DESCRIPTION
### These changes improve strategy security by implementing the following changes:

- Only valid if env variable is set, which is only set on session create action. This was copied over from authenticatable strategy.
- Also checks the idp entity id is present for the auth to be valid. This prevents ruby-saml errors when token is invalid
- Improve error messaging